### PR TITLE
Support envFrom and fix NEXTAUTH_URL

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -81,18 +81,6 @@ Persistence resources
 {{- end }}
 
 {{/*
-NextAuth URL
-Return the primary ingress host if enabled and defined; otherwise, return "localhost".
-*/}}
-{{- define "karakeep.nextAuthURL" -}}
-{{- if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) (index .Values.ingress.hosts 0).host }}
-  {{- (index .Values.ingress.hosts 0).host | quote -}}
-{{- else -}}
-  "localhost"
-{{- end -}}
-{{- end }}
-
-{{/*
 Return an env var definition for OPENAI_API_KEY if .Values.openAIApiKey is set.
 */}}
 {{- define "karakeep.openaiApiKey" -}}

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -67,6 +67,10 @@ spec:
                 secretKeyRef:
                   name: {{ default .Values.nextAuthSecret "nextauth-secret" }}
                   key: secret
+          {{- if and .Values.web .Values.web.envFrom }}
+          envFrom:
+            {{- toYaml .Values.web.envFrom | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -60,8 +60,6 @@ spec:
               value: http://{{ include "karakeep.fullname" . }}-chrome:9222
             - name: DATA_DIR
               value: {{ include "karakeep.persistenceVolumeMountPath" . }}
-            - name: NEXTAUTH_URL
-              value: {{ include "karakeep.nextAuthURL" . }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -141,13 +141,13 @@ affinity: {}
 # https://docs.karakeep.app/configuration/
 # https://github.com/karakeep-app/karakeep/blob/main/packages/shared/config.ts
 
-web:
-  envFrom:
-    - secretRef:
-        name: secret-name
-    - configMapRef:
-        name: config-map-name
-
+#web:
+#  envFrom:
+#    - secretRef:
+#        name: secret-name
+#    - configMapRef:
+#        name: config-map-name
+#
 #   extraEnv:
 #     DATA_DIR: /data
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -141,7 +141,13 @@ affinity: {}
 # https://docs.karakeep.app/configuration/
 # https://github.com/karakeep-app/karakeep/blob/main/packages/shared/config.ts
 
-# web:
+web:
+  envFrom:
+    - secretRef:
+        name: secret-name
+    - configMapRef:
+        name: config-map-name
+
 #   extraEnv:
 #     DATA_DIR: /data
 


### PR DESCRIPTION
Thanks for creating this HELM chart you saved me lots of time. 

When I deployed I found 2 small shortcomings. 

1. I use Authenik and requires a few ENV variable that I handle with sealed-secrets. Is more convenient to pass them all as a single `Secret` passed in an `envFrom`
2. You generate the `NEXTAUTH_URL` from Ingress but ingress requries a Host and `NEXTAUTH_URL` a URL and (i.e. https piece is required) and for me this resulted in the web container to keep crashing. 

Let me know what you think!